### PR TITLE
Added support for Scala 2.11.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: scala
 scala:
-   - 2.9.2
    - 2.10.0
+   - 2.11.6

--- a/build.sbt
+++ b/build.sbt
@@ -2,15 +2,15 @@ organization := "io.mth"
 
 name := "unfiltered-cors"
 
-scalaVersion := "2.10.0"
+scalaVersion := "2.11.6"
 
-crossScalaVersions := Seq("2.9.2", "2.10.0")
+crossScalaVersions := Seq("2.10.0", "2.11.6")
 
 libraryDependencies ++= Seq(
-  "net.databinder" %% "unfiltered" % "0.6.7",
-  "net.databinder" %% "unfiltered-filter" % "0.6.7" % "test",
-  "net.databinder" %% "unfiltered-jetty" % "0.6.7" % "test",
-  "io.argonaut" %% "argonaut" % "6.0-M3" % "test"
+  "net.databinder" %% "unfiltered" % "0.8.4",
+  "net.databinder" %% "unfiltered-filter" % "0.8.4" % "test",
+  "net.databinder" %% "unfiltered-jetty" % "0.8.4" % "test",
+  "io.argonaut" %% "argonaut" % "6.1" % "test"
 )
 
 resolvers ++= Seq(
@@ -19,7 +19,7 @@ resolvers ++= Seq(
   "oss releases" at "http://oss.sonatype.org/content/repositories/releases"
 )
 
-releaseSettings
+releaseCrossBuild := true
 
 publishMavenStyle := true
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=0.12.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin(("com.typesafe.sbt" % "sbt-pgp" % "0.7").cross(CrossVersion.full))
+addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.7")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.0")

--- a/sbt
+++ b/sbt
@@ -4,7 +4,7 @@
 # Author: Paul Phillips <paulp@typesafe.com>
 
 # todo - make this dynamic
-declare -r sbt_release_version=0.11.3
+declare -r sbt_release_version=0.13.6
 declare -r sbt_snapshot_version=0.13.0-SNAPSHOT
 
 unset sbt_jar sbt_dir sbt_create sbt_snapshot sbt_launch_dir


### PR DESCRIPTION
Upgraded API to support Scala 2.11.x. This required upgrading to later versions
of Unfiltered that no longer support Scala 2.10.x.

The build also now depends on SBT 0.13.8+. SBT plugins were updated to latest
versions accordingly.
